### PR TITLE
Support CPU-only QRNN.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -47,6 +47,19 @@ class TestHidden(unittest.TestCase):
         for hid in hidden:
             print(hid.size())
 
+class TestQRNN(unittest.TestCase):
+    def test(self):
+        model = drnn.DRNN(10, 10, 4, 0, 'QRNN')
+
+        x = torch.autograd.Variable(torch.randn(23, 3, 10))
+
+        hidden = model(x)[1]
+
+        self.assertEqual(len(hidden), 4)
+
+        for hid in hidden:
+            print(hid.size())
+
 
 class TestPassHidden(unittest.TestCase):
     def test(self):


### PR DESCRIPTION
The previous build previously propagate the use or disuse of CPU-only QRNNs to model creation.

This has been corrected, and I've added a unit test to ensure that it runs as expected.